### PR TITLE
Remove extra intersections for 'almost' method

### DIFF
--- a/curve/_geomalg.py
+++ b/curve/_geomalg.py
@@ -427,8 +427,15 @@ def segment_to_segment(segment1: 'Segment', segment2: 'Segment', tol: float = F_
     return t1, t2
 
 
-def segments_to_segments(data1: np.ndarray, data2: np.ndarray, tol: float = F_EPS) \
-        -> ty.Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+SegmentsToSegmentsResult = ty.NamedTuple('SegmentsToSegmentsResult', [
+    ('t1', np.ndarray),
+    ('t2', np.ndarray),
+    ('p1', np.ndarray),
+    ('p2', np.ndarray),
+])
+
+
+def segments_to_segments(data1: np.ndarray, data2: np.ndarray, tol: float = F_EPS) -> SegmentsToSegmentsResult:
     """Computes the shortest segments between all segment pairs from two segment sets
 
     Computes the shortest segments between all segment pairs and returns M1xM2 matrices for t1 and t2 parameters.
@@ -444,14 +451,12 @@ def segments_to_segments(data1: np.ndarray, data2: np.ndarray, tol: float = F_EP
 
     Returns
     -------
-    t1 : np.ndarray
-        M1xM2 matrix fot t1 parameter
-    t2 : np.ndarray
-        M1xM2 matrix fot t2 parameter
-    p1 : np.ndarray
-        NxM1xM2 array of beginning points of shortest segments on the first segments
-    p2 : np.ndarray
-        NxM1xM2 array of ending points of shortest segments on the second segments
+    result : SegmentsToSegmentsResult
+        The result in named tuple:
+            - ``t1`` : [np.ndarray] M1xM2 matrix fot t1 parameter
+            - ``t2`` : [np.ndarray] M1xM2 matrix fot t2 parameter
+            - ``p1`` : [np.ndarray] NxM1xM2 array of beginning points of shortest segments on the first segments
+            - ``p2`` : [np.ndarray] NxM1xM2 array of ending points of shortest segments on the second segments
 
     Notes
     -----
@@ -553,4 +558,4 @@ def segments_to_segments(data1: np.ndarray, data2: np.ndarray, tol: float = F_EP
     p1 = p11 + t1 * u
     p2 = p21 + t2 * v
 
-    return t1, t2, p1, p2
+    return SegmentsToSegmentsResult(t1, t2, p1, p2)

--- a/curve/_intersect.py
+++ b/curve/_intersect.py
@@ -602,9 +602,9 @@ class AlmostIntersectionMethod(IntersectionMethodBase):
         return NOT_INTERSECTED
 
     def _intersect_curves(self, curve1: 'Curve', curve2: 'Curve') -> ty.List[SegmentsIntersection]:
-        t1, t2, p1, p2 = _geomalg.segments_to_segments(curve1.data, curve2.data)
+        s2s = _geomalg.segments_to_segments(curve1.data, curve2.data)
 
-        dist = np.sum((p1 - p2)**2, axis=0)
+        dist = np.sum((s2s.p1 - s2s.p2)**2, axis=0)
 
         intersect_matrix = dist < self._almost_tol
         self_intersect = curve1 is curve2
@@ -616,18 +616,18 @@ class AlmostIntersectionMethod(IntersectionMethodBase):
 
         intersections = []
 
-        for segment1, segment2, t1_, t2_ in zip(curve1.segments[s1].tolist(),
-                                                curve2.segments[s2].tolist(),
-                                                t1[s1, s2].tolist(),
-                                                t2[s1, s2].tolist()):
+        for seg1, seg2, p1, p2 in zip(curve1.segments[s1].tolist(),
+                                      curve2.segments[s2].tolist(),
+                                      s2s.p1[:, s1, s2].T.tolist(),
+                                      s2s.p2[:, s1, s2].T.tolist()):
             shortest_segment = curve._base.Segment(
-                p1=segment1.point(t1_),
-                p2=segment2.point(t2_),
+                p1=curve._base.Point(p1),
+                p2=curve._base.Point(p2),
             )
 
             intersections.append(SegmentsIntersection(
-                segment1=segment1,
-                segment2=segment2,
+                segment1=seg1,
+                segment2=seg2,
                 intersect_info=IntersectionType.ALMOST(shortest_segment),
             ))
 

--- a/curve/_intersect.py
+++ b/curve/_intersect.py
@@ -650,9 +650,9 @@ class AlmostIntersectionMethod(IntersectionMethodBase):
         The algorithm:
             1. Find all intersections with intersection points which the distance between them less than 'extra_tol'
             2. Make the undirected graph from these intersection indices
-            3. Find connected components in the graph
-            4. Sort intersections in each component by 'intersect_segment' length
-            5. Add all [1:] intersections in each component to 'extra_intersections'
+            3. Find connected components in the graph (intersection blobs)
+            4. Sort intersections in each blob by 'intersect_segment' length
+            5. Add [1:] intersections in each sorted blob to 'extra_intersections'
                (keep the intersection with shortest 'intersect_segment')
             6. Remove from the intersections list 'extra_intersections' subset
         """
@@ -662,19 +662,19 @@ class AlmostIntersectionMethod(IntersectionMethodBase):
         dists = pdist(np.asarray(intersect_points))
         dists[dists < self._extra_tol] = np.nan
 
-        extra_matrix = np.isnan(squareform(dists))
-        ti, tj = np.tril_indices(extra_matrix.shape[0], k=0)
-        extra_matrix[ti, tj] = False
-        ei, ej = np.nonzero(extra_matrix)
+        extra_intersections_matrix = np.isnan(squareform(dists))
+        ti, tj = np.tril_indices(extra_intersections_matrix.shape[0], k=0)
+        extra_intersections_matrix[ti, tj] = False
+        ei, ej = np.nonzero(extra_intersections_matrix)
 
         extra_intersections_graph = nx.Graph()
         extra_intersections_graph.add_edges_from(zip(ei, ej))
 
         extra_intersections = []
 
-        for extra_components in nx.connected_components(extra_intersections_graph):
+        for blob_intersection_indices in nx.connected_components(extra_intersections_graph):
             extra_intersections.extend(
-                sorted([intersections[i] for i in extra_components],
+                sorted([intersections[i] for i in blob_intersection_indices],
                        key=lambda x: x.intersect_segment.seglen)[1:]
             )
 

--- a/curve/_intersect.py
+++ b/curve/_intersect.py
@@ -646,6 +646,15 @@ class AlmostIntersectionMethod(IntersectionMethodBase):
     def _remove_extra_intersections(self, intersections: ty.List[SegmentsIntersection]) \
             -> ty.List[SegmentsIntersection]:
         """Removes extra intersections
+
+        The algorithm:
+            1. Find all intersections with intersection points which the distance between them less than 'extra_tol'
+            2. Make the undirected graph from these intersection indices
+            3. Find connected components in the graph
+            4. Sort intersections in each component by 'intersect_segment' length
+            5. Add all [1:] intersections in each component to 'extra_intersections'
+               (keep the intersection with shortest 'intersect_segment')
+            6. Remove from the intersections list 'extra_intersections' subset
         """
 
         intersect_points = [i.intersect_point for i in intersections]

--- a/curve/_intersect.py
+++ b/curve/_intersect.py
@@ -12,7 +12,6 @@ import typing_extensions as ty_ext
 import abc
 import warnings
 import enum
-import heapq
 
 import numpy as np
 from scipy.spatial.distance import pdist, squareform
@@ -662,13 +661,15 @@ class AlmostIntersectionMethod(IntersectionMethodBase):
         duplicates_graph = nx.Graph()
         duplicates_graph.add_edges_from(zip(di, dj))
 
-        unique_intersections = []
+        extra_intersections = []
 
         for duplicate_components in nx.connected_components(duplicates_graph):
             duplicate_intersections = [intersections[i] for i in duplicate_components]
-            unique_intersection = heapq.nsmallest(1, duplicate_intersections,
-                                                  key=lambda x: x.intersect_segment.seglen)[0]
-            unique_intersections.append(unique_intersection)
+            duplicate_intersections.sort(key=lambda x: x.intersect_segment.seglen)
+            extra_intersections.extend(duplicate_intersections[1:])
+
+        extra_intersections = set(extra_intersections)
+        unique_intersections = list(filter(lambda x: x not in extra_intersections, intersections))
 
         return unique_intersections
 

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
     install_requires=[
         'numpy',
         'scipy',
+        'networkx',
         'csaps >= 0.6.0',
         'cached_property',
         'typing-extensions',

--- a/tests/test_intersect.py
+++ b/tests/test_intersect.py
@@ -182,3 +182,12 @@ def test_intersect_curves_almost():
 
     for intersection, expected_point in zip(intersections, expected_intersect_points):
         assert intersection.intersect_point == expected_point
+
+
+def test_intersect_curves_almost_remove_extra():
+    curve1 = curves.helix(p_count=456)
+    curve2 = curves.helix(a=-1, b=-1, p_count=321)
+
+    intersections = curve1.intersect(curve2, method='almost', dist_tol=0.001, remove_extra=True, extra_tol=0.1)
+
+    assert len(intersections) == 6

--- a/tests/test_intersect.py
+++ b/tests/test_intersect.py
@@ -171,7 +171,7 @@ def test_intersect_curves_almost():
     curve1 = curves.helix(t_start=-np.pi, t_stop=np.pi * 3, p_count=100)
     curve2 = curves.helix(t_start=-np.pi, t_stop=np.pi * 3, a=-1, b=-1, p_count=100)
 
-    intersections = curve1.intersect(curve2, method='almost', almost_tol=0.00001)
+    intersections = curve1.intersect(curve2, method='almost', dist_tol=0.00001)
 
     assert len(intersections) == 2
 

--- a/tests/test_intersect.py
+++ b/tests/test_intersect.py
@@ -184,10 +184,10 @@ def test_intersect_curves_almost():
         assert intersection.intersect_point == expected_point
 
 
-def test_intersect_curves_almost_remove_extra():
-    curve1 = curves.helix(p_count=456)
-    curve2 = curves.helix(a=-1, b=-1, p_count=321)
-
-    intersections = curve1.intersect(curve2, method='almost', dist_tol=0.001, remove_extra=True, extra_tol=0.1)
-
-    assert len(intersections) == 6
+@pytest.mark.parametrize('curve1, curve2, dist_tol, extra_tol, num_ints', [
+    (curves.helix(p_count=456), curves.helix(a=-1, b=-1, p_count=321), 0.001, 0.1, 6),
+    (curves.helix(p_count=456), curves.irregular_helix(p_count=321), 0.01, 0.1, 1),
+])
+def test_intersect_curves_almost_remove_extra(curve1, curve2, dist_tol, extra_tol, num_ints):
+    intersections = curve1.intersect(curve2, method='almost', dist_tol=dist_tol, extra_tol=extra_tol, remove_extra=True)
+    assert len(intersections) == num_ints


### PR DESCRIPTION
When we use `almost` intersection method we can remove extra (parasitic) intersections using association of intersections in the blobs and excluding from these blobs all but one intersections which were sorted by intersection segment lengths. The described approach will work fine for most cases.
